### PR TITLE
added config option discard-auto-indented-whitespace

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -53,6 +53,7 @@
 | `workspace-lsp-roots` | Directories relative to the workspace root that are treated as LSP roots. Should only be set in `.helix/config.toml` | `[]` |
 | `default-line-ending` | The line ending to use for new documents. Can be `native`, `lf`, `crlf`, `ff`, `cr` or `nel`. `native` uses the platform's native line ending (`crlf` on Windows, otherwise `lf`). | `native` |
 | `insert-final-newline` | Whether to automatically insert a trailing line-ending on write if missing | `true` |
+| `discard-auto-indented-whitespace` | Whether to automatically trim indented whitespace created by opening a newline | `true` |
 | `popup-border` | Draw border around `popup`, `menu`, `all`, or `none` | `none` |
 | `indent-heuristic` | How the indentation for a newly inserted line is computed: `simple` just copies the indentation level from the previous line, `tree-sitter` computes the indentation based on the syntax tree and `hybrid` combines both approaches. If the chosen heuristic is not available, a different one will be used as a fallback (the fallback order being `hybrid` -> `tree-sitter` -> `simple`). | `hybrid`
 | `jump-label-alphabet` | The characters that are used to generate two character jump labels. Characters at the start of the alphabet are used first. | `"abcdefghijklmnopqrstuvwxyz"`

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4033,9 +4033,13 @@ pub mod insert {
             let continue_comment_token = continue_comment_tokens
                 .and_then(|tokens| comment::get_comment_token(text, tokens, current_line));
 
-            let (from, to, local_offs) = if let Some(idx) =
+            let line_end_idx = if cx.editor.config().discard_auto_indented_whitespace {
                 text.slice(line_start..pos).last_non_whitespace_char()
-            {
+            } else {
+                Some(pos)
+            };
+
+            let (from, to, local_offs) = if let Some(idx) = line_end_idx {
                 let first_trailing_whitespace_char = (line_start + idx + 1).min(pos);
                 let line = text.line(current_line);
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -342,6 +342,8 @@ pub struct Config {
     pub default_line_ending: LineEndingConfig,
     /// Whether to automatically insert a trailing line-ending on write if missing. Defaults to `true`.
     pub insert_final_newline: bool,
+    /// Whether to keep auto-inserted whitespace indentation on newline. Defaults to `false`.
+    pub discard_auto_indented_whitespace: bool,
     /// Enables smart tab
     pub smart_tab: Option<SmartTabConfig>,
     /// Draw border around popups.
@@ -994,6 +996,7 @@ impl Default for Config {
             workspace_lsp_roots: Vec::new(),
             default_line_ending: LineEndingConfig::default(),
             insert_final_newline: true,
+            discard_auto_indented_whitespace: true,
             smart_tab: Some(SmartTabConfig::default()),
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),


### PR DESCRIPTION
Defaults to true. When disabled, the whitespace created for indentation will not be discarded if the line is left blank when exiting insert mode or pressing return. This prevents having to re-indent lines initially created as space holders before or after adding the desired text. This also helps visually to see indentation when rendering all whitespace is enabled.